### PR TITLE
Dockerfiles

### DIFF
--- a/docker/beagle5.4/Dockerfile
+++ b/docker/beagle5.4/Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 FROM ubuntu:16.04
-MAINTAINER Jiayong Li <jli@curii.com>
 USER root
 
 RUN apt-get update --fix-missing -qy

--- a/docker/cgivar2vcfbed/Dockerfile
+++ b/docker/cgivar2vcfbed/Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 FROM arvados/jobs
-MAINTAINER Jiayong Li <jli@curii.com>
 
 USER root
 

--- a/docker/cgivar2vcfbed/Dockerfile
+++ b/docker/cgivar2vcfbed/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0
 
-FROM arvados/jobs
+FROM python:3.8-buster
 
 USER root
 

--- a/docker/lightning/Dockerfile
+++ b/docker/lightning/Dockerfile
@@ -5,8 +5,7 @@
 # build instruction:
 # docker build -t dockername --file=/path/to/lightning/docker/lightning/Dockerfile /path/to/lightning
 
-FROM ubuntu:latest
-MAINTAINER Jiayong Li <jli@curii.com>s
+FROM python:3.8-buster
 USER root
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -24,8 +23,6 @@ RUN apt-get install -qy --no-install-recommends wget \
   libncursesw5-dev \
   gcc \
   make \
-  python3.8 \
-  python3-pip \
   python3-numpy \
   python3-pandas \
   python3-scipy \

--- a/docker/lightning/Dockerfile
+++ b/docker/lightning/Dockerfile
@@ -7,7 +7,6 @@
 
 FROM python:3.8-buster
 USER root
-ARG DEBIAN_FRONTEND=noninteractive
 
 # Install necessary dependencies
 

--- a/docker/snpeff/Dockerfile
+++ b/docker/snpeff/Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 FROM ubuntu:18.04
-MAINTAINER Jiayong Li <jli@curii.com>
 USER root
 
 # Install necessary dependencies

--- a/docker/vcfutil/Dockerfile
+++ b/docker/vcfutil/Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 FROM arvados/jobs
-MAINTAINER Jiayong Li <jli@curii.com>
 
 USER root
 

--- a/docker/vcfutil/Dockerfile
+++ b/docker/vcfutil/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0
 
-FROM arvados/jobs
+FROM python:3.8-buster
 
 USER root
 


### PR DESCRIPTION
This pull request accomplishes two things.
1) Remove `MAINTAINER` attribute from all Dockerfiles. `MAINTAINER` has been deprecated, and Jiayong is no longer maintaining the files.
2) Update base image. Primarily `arvados/jobs` -> `python:3.8-buster`